### PR TITLE
Implementation of Pokerus on the generations side. 

### DIFF
--- a/Generations/src/main/java/net/impactdev/pixelmonbridge/generations/GenerationsPokemon.java
+++ b/Generations/src/main/java/net/impactdev/pixelmonbridge/generations/GenerationsPokemon.java
@@ -16,6 +16,7 @@ import com.pixelmongenerations.common.entity.pixelmon.stats.extraStats.MeloettaS
 import com.pixelmongenerations.common.entity.pixelmon.stats.extraStats.MewStats;
 import com.pixelmongenerations.core.enums.EnumSpecies;
 import net.impactdev.pixelmonbridge.ImpactDevPokemon;
+import net.impactdev.pixelmonbridge.details.PixelmonSource;
 import net.impactdev.pixelmonbridge.details.Query;
 import net.impactdev.pixelmonbridge.details.SpecKey;
 import net.impactdev.pixelmonbridge.details.SpecKeys;
@@ -135,6 +136,7 @@ public class GenerationsPokemon implements ImpactDevPokemon<EntityPixelmon> {
 
         if(pokemon.pokerus > 0) {
             result.offer(SpecKeys.POKERUS, new Pokerus(
+                    PixelmonSource.Generations,
                     pokemon.pokerus,
                     pokemon.pokerusTimer / 20, //conversion from ticks to seconds
                     false)

--- a/Generations/src/main/java/net/impactdev/pixelmonbridge/generations/GenerationsPokemon.java
+++ b/Generations/src/main/java/net/impactdev/pixelmonbridge/generations/GenerationsPokemon.java
@@ -19,12 +19,7 @@ import net.impactdev.pixelmonbridge.ImpactDevPokemon;
 import net.impactdev.pixelmonbridge.details.Query;
 import net.impactdev.pixelmonbridge.details.SpecKey;
 import net.impactdev.pixelmonbridge.details.SpecKeys;
-import net.impactdev.pixelmonbridge.details.components.Ability;
-import net.impactdev.pixelmonbridge.details.components.EggInfo;
-import net.impactdev.pixelmonbridge.details.components.Level;
-import net.impactdev.pixelmonbridge.details.components.Moves;
-import net.impactdev.pixelmonbridge.details.components.Nature;
-import net.impactdev.pixelmonbridge.details.components.Trainer;
+import net.impactdev.pixelmonbridge.details.components.*;
 import net.impactdev.pixelmonbridge.details.components.generic.ItemStackWrapper;
 import net.impactdev.pixelmonbridge.details.components.generic.JSONWrapper;
 import net.impactdev.pixelmonbridge.generations.writer.GenerationsSpecKeyWriter;
@@ -39,7 +34,6 @@ import java.util.UUID;
 public class GenerationsPokemon implements ImpactDevPokemon<EntityPixelmon> {
 
     private final ImmutableList<SpecKey<?>> UNSUPPORTED = ImmutableList.copyOf(Lists.newArrayList(
-            SpecKeys.POKERUS,
             SpecKeys.MELTAN_ORES_SMELTED,
             SpecKeys.MAREEP_WOOL_GROWTH,
             SpecKeys.MINIOR_COLOR
@@ -137,6 +131,14 @@ public class GenerationsPokemon implements ImpactDevPokemon<EntityPixelmon> {
                     pokemon.eggCycles,
                     pokemon.writeToNBT(new NBTTagCompound()).getInteger("steps")
             ));
+        }
+
+        if(pokemon.pokerus > 0) {
+            result.offer(SpecKeys.POKERUS, new Pokerus(
+                    pokemon.pokerus,
+                    pokemon.pokerusTimer / 20, //conversion from ticks to seconds
+                    false)
+            );
         }
 
         result.offer(SpecKeys.HELD_ITEM, new ItemStackWrapper(pokemon.getHeldItem(EnumHand.MAIN_HAND)));

--- a/Generations/src/main/java/net/impactdev/pixelmonbridge/generations/GenerationsPokemon.java
+++ b/Generations/src/main/java/net/impactdev/pixelmonbridge/generations/GenerationsPokemon.java
@@ -139,7 +139,7 @@ public class GenerationsPokemon implements ImpactDevPokemon<EntityPixelmon> {
                     PixelmonSource.Generations,
                     pokemon.pokerus,
                     pokemon.pokerusTimer / 20, //conversion from ticks to seconds
-                    false)
+                    true)
             );
         }
 

--- a/Generations/src/main/java/net/impactdev/pixelmonbridge/generations/writer/GenerationsSpecKeyWriter.java
+++ b/Generations/src/main/java/net/impactdev/pixelmonbridge/generations/writer/GenerationsSpecKeyWriter.java
@@ -16,20 +16,13 @@ import com.pixelmongenerations.core.enums.EnumSpecies;
 import com.pixelmongenerations.core.enums.items.EnumPokeball;
 import net.impactdev.pixelmonbridge.details.SpecKey;
 import net.impactdev.pixelmonbridge.details.SpecKeys;
-import net.impactdev.pixelmonbridge.details.components.Ability;
-import net.impactdev.pixelmonbridge.details.components.EggInfo;
-import net.impactdev.pixelmonbridge.details.components.Level;
-import net.impactdev.pixelmonbridge.details.components.Moves;
-import net.impactdev.pixelmonbridge.details.components.Nature;
-import net.impactdev.pixelmonbridge.details.components.Trainer;
+import net.impactdev.pixelmonbridge.details.components.*;
 import net.impactdev.pixelmonbridge.details.components.generic.ItemStackWrapper;
 import net.impactdev.pixelmonbridge.details.components.generic.JSONWrapper;
-import net.impactdev.pixelmonbridge.details.components.generic.NBTWrapper;
 import net.minecraft.nbt.NBTTagCompound;
 
 import java.util.Map;
 import java.util.function.BiConsumer;
-import java.util.function.Consumer;
 
 public class GenerationsSpecKeyWriter {
 
@@ -111,6 +104,12 @@ public class GenerationsSpecKeyWriter {
             nbt = p.writeToNBT(nbt);
             nbt.setInteger("steps", info.getSteps());
             p.readFromNBT(nbt);
+        });
+        writers.put(SpecKeys.POKERUS, (p, v) -> {
+            Pokerus pokerus = (Pokerus) v;
+            p.pokerus = pokerus.getType();
+            p.pokerusTimer = pokerus.getSecondsSinceInfection() * 20; //pokerus  timer in gens is in seconds
+            // we also don't use the isAnnounced flag here
         });
         writers.put(SpecKeys.MOVESET, (p, v) -> {
             Moves moves = (Moves) v;


### PR DESCRIPTION
This includes both reading and writing from the PixelmonEntities. I also added some clarification in the Pokerus javadocs to cover the generations side.

# Few things to note:

### Generations has no Pokerus enum, only 3 int values which determine the current status of a pokemon:
- 0 = not infected
- 1 = infected
 - 2 = cured (can't be infected again)

### Generations PokerusTimer is in **ticks**
- I did the time conversion in the reading and writing process to ensure the Pokerus class always contains seconds